### PR TITLE
chore(renovate): extend the shared preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "dependencyDashboard": false,
   "extends": [
-    "config:recommended"
+    "github>brzzdev/renovate-config"
   ]
 }


### PR DESCRIPTION
Every brzzdev repo carried its own copy of `config:recommended` plus `dependencyDashboard: false`, and fourteen of them repeated the same Point-Free grouping verbatim. Changing that policy meant a PR per repo.

The rules now live in [brzzdev/renovate-config](https://github.com/brzzdev/renovate-config).

This repo extends the base preset — same `config:recommended`, same dashboard setting.

**Minor and patch updates now automerge.** CI gates it — Renovate will not merge a red branch — and 0.x minors stay manual, because a pre-1.0 minor can break while SPM resolves it happily and Renovate still labels it `minor`.

`automerge` is a separate opt-in preset rather than part of the baseline: no repo here protects `main`, so Renovate is the only gate, and a repo with no CI has nothing red to stop it. This repo has a real test job, so it opts in.