### PR TITLE
chore(renovate): automerge minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>brzzdev/renovate-config"
+    "github>brzzdev/renovate-config",
+    "github>brzzdev/renovate-config:automerge"
   ]
 }


### PR DESCRIPTION
The [shared preset rollout](https://github.com/brzzdev/renovate-config) merged here before the automerge preset existed, so this repo is on the presets but never picked up the automerge opt-in. This adds it.

**Minor and patch updates now automerge.** CI gates it — Renovate will not merge a red branch — and 0.x minors stay manual, because a pre-1.0 minor can break while the resolver accepts it happily and Renovate still labels it `minor`.

`automerge` is a separate opt-in preset rather than part of the baseline: no repo here protects `main`, so Renovate is the only gate, and a repo with no CI has nothing red to stop it. This repo has a real test job, so it opts in.